### PR TITLE
Add local storage persistence controls to checklist form

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,10 @@
       </div>
 
       <!-- Pulsanti di Esportazione -->
-      <div class="text-center mt-10 flex flex-col sm:flex-row gap-4 justify-center">
+      <div class="text-center mt-10 flex flex-col sm:flex-row flex-wrap gap-4 justify-center">
+        <button type="button" id="save-form" class="btn btn-primary text-lg">Salva</button>
+        <button type="button" id="restore-data" class="btn btn-secondary text-lg">Ripristina dati salvati</button>
+        <button type="button" id="clear-data" class="btn btn-secondary text-lg">Cancella dati salvati</button>
         <button type="button" id="export-vertical" class="btn btn-primary text-lg">Esporta CSV (Sezione;Campo;Valore)</button>
         <button type="button" id="export-wide" class="btn btn-secondary text-lg">Esporta per Stampa Unione (1 riga = 1 record)</button>
       </div>
@@ -150,35 +153,73 @@
       const addDipendenteBtn = document.getElementById('add-dipendente');
       const dipendentiContainer = document.getElementById('dipendenti-container');
       const notification = document.getElementById('notification');
+      const saveBtn = document.getElementById('save-form');
+      const restoreBtn = document.getElementById('restore-data');
+      const clearBtn = document.getElementById('clear-data');
 
       let macchinaCount = 0;
       let dipendenteCount = 0;
 
-      function addMacchina(){
+      function addMacchina(value = ''){
         macchinaCount++;
         const div = document.createElement('div');
         div.className = 'flex items-center gap-4 mb-4';
-        div.innerHTML = `
-          <input type="text" name="Attrezzatura_${macchinaCount}" class="form-input flex-grow" placeholder="Es. Affettatrice, Forno, Friggitrice...">
-          <button type="button" class="btn-danger btn remove-macchina">Rimuovi</button>
-        `;
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.name = `Attrezzatura_${macchinaCount}`;
+        input.className = 'form-input flex-grow';
+        input.placeholder = 'Es. Affettatrice, Forno, Friggitrice...';
+        input.value = value;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn-danger btn remove-macchina';
+        removeBtn.textContent = 'Rimuovi';
+
+        div.appendChild(input);
+        div.appendChild(removeBtn);
         macchineContainer.appendChild(div);
       }
 
-      function addDipendente(){
+      function addDipendente({ nome = '', mansione = '' } = {}){
         dipendenteCount++;
         const tr = document.createElement('tr');
-        tr.innerHTML = `
-          <td class="p-1"><input type="text" name="Dipendente_Nome_${dipendenteCount}" class="form-input" placeholder="Mario Rossi"></td>
-          <td class="p-1"><input type="text" name="Dipendente_Mansione_${dipendenteCount}" class="form-input" placeholder="Cuoco"></td>
-          <td class="p-1 text-center"><button type="button" class="btn-danger btn remove-dipendente">X</button></td>
-        `;
+
+        const tdNome = document.createElement('td');
+        tdNome.className = 'p-1';
+        const inputNome = document.createElement('input');
+        inputNome.type = 'text';
+        inputNome.name = `Dipendente_Nome_${dipendenteCount}`;
+        inputNome.className = 'form-input';
+        inputNome.placeholder = 'Mario Rossi';
+        inputNome.value = nome;
+        tdNome.appendChild(inputNome);
+
+        const tdMansione = document.createElement('td');
+        tdMansione.className = 'p-1';
+        const inputMansione = document.createElement('input');
+        inputMansione.type = 'text';
+        inputMansione.name = `Dipendente_Mansione_${dipendenteCount}`;
+        inputMansione.className = 'form-input';
+        inputMansione.placeholder = 'Cuoco';
+        inputMansione.value = mansione;
+        tdMansione.appendChild(inputMansione);
+
+        const tdActions = document.createElement('td');
+        tdActions.className = 'p-1 text-center';
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'btn-danger btn remove-dipendente';
+        removeBtn.textContent = 'X';
+        tdActions.appendChild(removeBtn);
+
+        tr.appendChild(tdNome);
+        tr.appendChild(tdMansione);
+        tr.appendChild(tdActions);
+
         dipendentiContainer.appendChild(tr);
       }
-
-      // elementi iniziali
-      addMacchina();
-      addDipendente();
 
       addMacchinaBtn.addEventListener('click', addMacchina);
       addDipendenteBtn.addEventListener('click', addDipendente);
@@ -196,6 +237,132 @@
         const t = String(text).replace(/"/g,'""').replace(/(\r\n|\n|\r)/gm,' ');
         return `"${t}"`;
       };
+
+      function collectFormData(){
+        const form = document.getElementById('safety-checklist-form');
+        const formData = new FormData(form);
+        const base = Object.fromEntries(formData.entries());
+
+        const attrezzature = [...macchineContainer.querySelectorAll('input[name^="Attrezzatura_"]')]
+          .map(inp => inp.value.trim())
+          .filter(value => value !== '');
+
+        const dipendenti = [...dipendentiContainer.querySelectorAll('tr')]
+          .map(row => {
+            const nome = row.querySelector('input[name^="Dipendente_Nome_"]')?.value.trim() || '';
+            const mansione = row.querySelector('input[name^="Dipendente_Mansione_"]')?.value.trim() || '';
+            return { nome, mansione };
+          })
+          .filter(({ nome, mansione }) => nome !== '' || mansione !== '');
+
+        return {
+          Denominazione: base['Denominazione'] || '',
+          P_IVA: base['P_IVA'] || '',
+          Sede_Legale: base['Sede_Legale'] || '',
+          Sede_Operativa: base['Sede_Operativa'] || '',
+          Mail: base['Mail'] || '',
+          Telefono: base['Telefono'] || '',
+          Legale_Rappresentante: base['Legale_Rappresentante'] || '',
+          RSPP: base['RSPP'] || '',
+          RLS: base['RLS'] || '',
+          Medico_Competente: base['Medico_Competente'] || '',
+          Addetti_Antincendio: base['Addetti_Antincendio'] || '',
+          Addetti_Primo_Soccorso: base['Addetti_Primo_Soccorso'] || '',
+          Preposto: base['Preposto'] || '',
+          Aree_Aziendali: base['Aree_Aziendali'] || '',
+          Ciclo_Lavorativo: base['Ciclo_Lavorativo'] || '',
+          Attrezzature: attrezzature,
+          Dipendenti: dipendenti
+        };
+      }
+
+      function populateForm(data){
+        if (!data || typeof data !== 'object') return;
+
+        const setValue = (id, value = '') => {
+          const el = document.getElementById(id);
+          if (el) el.value = value;
+        };
+
+        setValue('denominazione', data.Denominazione);
+        setValue('p_iva', data.P_IVA);
+        setValue('sede_legale', data.Sede_Legale);
+        setValue('sede_operativa', data.Sede_Operativa);
+        setValue('mail', data.Mail);
+        setValue('telefono', data.Telefono);
+        setValue('legale_rappresentante', data.Legale_Rappresentante);
+        setValue('rspp', data.RSPP);
+        setValue('rls', data.RLS);
+        setValue('medico_competente', data.Medico_Competente);
+        setValue('addetti_antincendio', data.Addetti_Antincendio);
+        setValue('addetti_primo_soccorso', data.Addetti_Primo_Soccorso);
+        setValue('preposto', data.Preposto);
+        setValue('aree_aziendali', data.Aree_Aziendali);
+        setValue('ciclo_lavorativo', data.Ciclo_Lavorativo);
+
+        macchineContainer.innerHTML = '';
+        macchinaCount = 0;
+        const attrezzature = Array.isArray(data.Attrezzature) && data.Attrezzature.length
+          ? data.Attrezzature
+          : [''];
+        attrezzature.forEach(value => addMacchina(value));
+
+        dipendentiContainer.innerHTML = '';
+        dipendenteCount = 0;
+        const dipendenti = Array.isArray(data.Dipendenti) && data.Dipendenti.length
+          ? data.Dipendenti
+          : [{}];
+        dipendenti.forEach(persona => addDipendente({
+          nome: persona?.nome || '',
+          mansione: persona?.mansione || ''
+        }));
+      }
+
+      function showNotification(message){
+        if (notification){
+          notification.textContent = message;
+          notification.classList.add('show');
+          setTimeout(()=>notification.classList.remove('show'), 2500);
+        }
+      }
+
+      saveBtn.addEventListener('click', () => {
+        try {
+          const data = collectFormData();
+          const jsonString = JSON.stringify(data);
+          localStorage.setItem('checklistData', jsonString);
+          showNotification('Dati salvati localmente!');
+        } catch (error) {
+          console.error('Errore durante il salvataggio dei dati', error);
+          showNotification('Errore durante il salvataggio dei dati.');
+        }
+      });
+
+      restoreBtn.addEventListener('click', () => {
+        try {
+          const stored = localStorage.getItem('checklistData');
+          if (stored){
+            const data = JSON.parse(stored);
+            populateForm(data);
+            showNotification('Dati salvati ripristinati!');
+          } else {
+            showNotification('Nessun dato salvato da ripristinare.');
+          }
+        } catch (error) {
+          console.error('Errore durante il ripristino dei dati salvati', error);
+          showNotification('Errore durante il ripristino dei dati.');
+        }
+      });
+
+      clearBtn.addEventListener('click', () => {
+        try {
+          localStorage.removeItem('checklistData');
+          showNotification('Dati salvati eliminati.');
+        } catch (error) {
+          console.error('Errore durante la cancellazione dei dati salvati', error);
+          showNotification('Errore durante la cancellazione dei dati.');
+        }
+      });
 
       // esportazione verticale Sezione;Campo;Valore (come il tuo attuale)
       document.getElementById('export-vertical').addEventListener('click', () => {
@@ -240,7 +407,7 @@
         if(base['Ciclo_Lavorativo']) pushRow('Ciclo Lavorativo', 'Descrizione', base['Ciclo_Lavorativo']);
 
         downloadCSV(csv, 'checklist_sicurezza.csv');
-        toast();
+        showNotification('Dati esportati con successo!');
       });
 
       // esportazione WIDE: 1 riga = 1 record (intestazioni = campi) -> perfetto per Stampa Unione
@@ -291,7 +458,7 @@
         const csv = headers.join(';') + '\n' + values.join(';') + '\n';
 
         downloadCSV(csv, 'checklist_sicurezza_mailmerge.csv');
-        toast();
+        showNotification('Dati esportati con successo!');
       });
 
       function downloadCSV(content, filename){
@@ -303,9 +470,19 @@
         URL.revokeObjectURL(url); a.remove();
       }
 
-      function toast(){
-        notification.classList.add('show');
-        setTimeout(()=>notification.classList.remove('show'), 2500);
+      const stored = localStorage.getItem('checklistData');
+      if (stored) {
+        try {
+          const data = JSON.parse(stored);
+          populateForm(data);
+        } catch (error) {
+          console.error('Errore durante il caricamento dei dati salvati', error);
+          addMacchina();
+          addDipendente();
+        }
+      } else {
+        addMacchina();
+        addDipendente();
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- add toolbar controls to save, restore, and clear checklist data
- persist compiled form data to localStorage with error handling
- automatically repopulate static and dynamic fields when saved data exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa66ac19c832fab0616c12a16666a